### PR TITLE
Fix an error when user is undefined

### DIFF
--- a/common/likeable-model.js
+++ b/common/likeable-model.js
@@ -47,7 +47,7 @@ export default ({ Meteor, LinkParent, LikesCollection, Like }) => {
         * @returns {Mongo.Cursor} A mongo cursor which returns Like instances
         */
         likesBy(user) {
-            const userId = user._id || user;
+            const userId = user?._id || user;
             return LikesCollection.find({ userId, linkedObjectId: this._id }, { limit: 1 });
         }
 
@@ -58,7 +58,7 @@ export default ({ Meteor, LinkParent, LikesCollection, Like }) => {
         * @returns {Boolean} Wheter the user likes the model or not
         */
         isLikedBy(user) {
-            const userId = user._id || user;
+            const userId = user?._id || user;
             return !!LikesCollection.findOne({ linkedObjectId: this._id, userId });
         }
     };

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@
 Package.describe({
     name: 'socialize:likeable',
     summary: 'A package implementing social "liking" or "starring"',
-    version: '1.0.4',
+    version: '1.0.5',
     git: 'https://github.com/copleykj/socialize-likeable.git',
 });
 


### PR DESCRIPTION
When undefined user is passed into `likesBy` or `isLikedBy` functions they will throw that it cannot find `_id` of `undefined`. Adding conditional chaining helps to alleviate the issue.